### PR TITLE
Add context to payloadValidator

### DIFF
--- a/src/hono-middleware.ts
+++ b/src/hono-middleware.ts
@@ -5,7 +5,7 @@ import { getJwks, useKVStore, verify } from '.';
 export type VerifyRsaJwtConfig = {
   jwksUri?: string;
   kvStore?: GeneralKeyValueStore;
-  payloadValidator?: (payload: VerificationResult) => void;
+  payloadValidator?: (payload: VerificationResult, ctx: Context) => void;
   verbose?: boolean;
 };
 
@@ -31,7 +31,7 @@ export function verifyRsaJwt(config?: VerifyRsaJwtConfig): MiddlewareHandler {
       }
 
       // Custom validator that should throw an error if the payload is invalid.
-      config?.payloadValidator?.(result);
+      config?.payloadValidator?.(result, ctx);
 
       // Accessible payload.
       ctx.set(PAYLOAD_KEY, result.payload);


### PR DESCRIPTION
Hi,

For most common use cases; one is going to need to check (at least) `iss`, `aud` and `iat`.
Issuer and Audience are likely to be stored in bindings, so to allow this check, I propose passing `ctx` as a second argument to `payloadValidator`