### PR TITLE
fix(verify): handle - and _ characters in jwt token correctly

### DIFF
--- a/src/verify.ts
+++ b/src/verify.ts
@@ -44,7 +44,7 @@ function parseToken(token: string): {
   let payload;
   try {
     // kid = JSON.parse(atob(tokenParts[0])).kid; - kid is optional. Cannot always expect.
-    payload = JSON.parse(atob(tokenParts[1]));
+    payload = JSON.parse(atob(tokenParts[1].replace(/-/g, `+`).replace(/_/g, `/`)));
   } catch (error) {
     throw new Error('Invalid token format');
   }


### PR DESCRIPTION
I've encountered oidc tokens that contain - and _ characters in their payload part and atob function throws an error on it.

Seems to be same to the issue I found there:
https://github.com/AzureAD/microsoft-authentication-library-for-js/issues/6492#issuecomment-1738757566